### PR TITLE
feat: class methods use `this`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     camelcase: 'error',
     complexity: 'error',
     curly: ['error', 'multi-line'],
+    'class-methods-use-this': 'error',
     'eol-last': 'error',
     eqeqeq: ['error', 'smart'],
     'guard-for-in': 'error',


### PR DESCRIPTION
https://eslint.org/docs/rules/class-methods-use-this

ok, this one's probably gonna generate some discussion.

The downsides of private methods in a class that don't use this

1. they're hard to test.

Whatever they're doing would be easier as a a funciton (either in the same file or a separate file) that could be imported and tested.  You end up mocking an entire class.

2. they change the class signature (hey, these 2 classes don't match because they have a different implementation of private method foo) when really consumers shouldn't have to know about its private methods

3.  If you think the method needs to be used publicly but it doesn't care about the classes member properties, how about a public static method?

---

if it's a function outside the class, you can always make it a private method later if it needs member access without breaking anything